### PR TITLE
Root document Minimap parameter

### DIFF
--- a/src/plugin/minimap/index.js
+++ b/src/plugin/minimap/index.js
@@ -67,6 +67,7 @@ export default class MinimapPlugin {
                 overviewZIndex: params.overviewZIndex || 2,
                 // the container should be different
                 container: false,
+                rootDocument: false,
                 height: Math.max(Math.round(ws.params.height / 4), 20),
                 widthRatio: params.width || 1
             },
@@ -116,7 +117,7 @@ export default class MinimapPlugin {
             }
             // if there is no such element, append it to the container (below
             // the waveform)
-            if (!document.body.contains(this.params.container)) {
+            if (!document.body.contains(this.params.container) && !this.params.rootDocument || !this.params.rootDocument.contains(this.params.container)){
                 ws.container.insertBefore(this.params.container, null);
             }
 


### PR DESCRIPTION
Added the option to include a root document element as a parameter for the Minimap plugin.

This is to take into account the case where the `container` parameter lies within a shadow DOM, so it originally won't be found and the minimap will be appended on the `waveform` element as a default.

Now it will first check if the container is on the default `document.body`, then if not it'll check if there is a value in the new `rootDocument` parameter. It'll then check that document for the `container` instead of checking the `document.body`.